### PR TITLE
Fix: content overflow and existing padding of ul element

### DIFF
--- a/src/components/footer.scss
+++ b/src/components/footer.scss
@@ -56,6 +56,7 @@ footer {
 
   .footer-contact {
     ul {
+      padding: 0px;
       list-style: none;
     }
 

--- a/src/components/newsCard.scss
+++ b/src/components/newsCard.scss
@@ -46,6 +46,7 @@
     width: 50%;
     padding: 25px 15px;
     text-align: left;
+    overflow: hidden;
 
     a {
       text-decoration: none;


### PR DESCRIPTION
Hide content overflow from News component and removed extra padding from footer-contact